### PR TITLE
Use the Self-Hosted Runners

### DIFF
--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -18,11 +18,10 @@ jobs:
   buildandtest:
     name: Build and Test
     uses: ./.github/workflows/build-and-test.yml
-    secrets: inherit
   iosapptestflightdeployment:
     name: iOS App TestFlight Deployment
     needs: buildandtest
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    uses: CS342/.github/.github/workflows/xcodebuild-or-fastlane.yml@v1
     secrets: inherit
     with:
       artifactname: GetMoovin.xcresult

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the CS342 2023 GetMoovin Team Application project
+# This source file is part of the CS342 2023 Allergy Team Application project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University
 #
@@ -16,16 +16,16 @@ on:
 jobs:
   reuse_action:
     name: REUSE Compliance Check
-    uses: StanfordBDHG/.github/.github/workflows/reuse.yml@v1
+    uses: StanfordBDHG/.github/.github/workflows/reuse.yml@v2
   swiftlint:
     name: SwiftLint
-    uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v1
+    uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v2
   buildandtest:
     name: Build and Test
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    uses: CS342/.github/.github/workflows/xcodebuild-or-fastlane.yml@v1
     with:
       artifactname: GetMoovin.xcresult
-      runsonlabels: '["macos-latest"]'
+      runsonlabels: '["macOS", "self-hosted"]'
       fastlanelane: test
   uploadcoveragereport:
     name: Upload Coverage Report

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the CS342 2023 Allergy Team Application project
+# This source file is part of the CS342 2023 GetMoovin Team Application project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University
 #


### PR DESCRIPTION
# Use the Self-Hosted Runners

## :bulb: Proposed solution
- Switches to a reusable workflow and uses the self-hosted runners.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
