### PR TITLE
Add HKAnchoredObjectQueryDescriptor

### DIFF
--- a/GetMoovin/TodaysGoal/StepCountView.swift
+++ b/GetMoovin/TodaysGoal/StepCountView.swift
@@ -22,10 +22,10 @@ struct StepCountView: View {
     @EnvironmentObject var stepCountDataSource: StepCountDataSource
     @AppStorage(StorageKeys.userInformation) var userInformation = UserInformation()
     
-    @State var todaysSteps: Int?
+    
     var body: some View {
         let data: [StepsInfo] = [
-            .init(type: "Steps", count: todaysSteps ?? 7000, color: "Blue"),
+            .init(type: "Steps", count: stepCountDataSource.todaysSteps ?? 7000, color: "Blue"),
             .init(type: "Steps", count: 10000, color: "Grey")
         ]
         Chart {
@@ -39,7 +39,7 @@ struct StepCountView: View {
         }
         ScrollView {
             VStack {
-                if let todaysSteps {
+                if let todaysSteps = stepCountDataSource.todaysSteps {
                     Text("Today's step count: \(todaysSteps)")
                 } else {
                     ProgressView()
@@ -48,19 +48,6 @@ struct StepCountView: View {
                     Text("The goal is: \(stepGoal)")
                 }
             }
-        }
-            .refreshable {
-                loadStepCount()
-            }
-            .onAppear {
-                loadStepCount()
-            }
-    }
-    
-    
-    private func loadStepCount() {
-        Task {
-            todaysSteps = await stepCountDataSource.todaysSteps
         }
     }
 }

--- a/GetMoovinModules/Sources/GetMoovinStepCountModule/MockStepCountDataSource.swift
+++ b/GetMoovinModules/Sources/GetMoovinStepCountModule/MockStepCountDataSource.swift
@@ -12,15 +12,7 @@ import Foundation
 /// <#Description#>
 public class MockStepCountDataSource: StepCountDataSource {
     private let _todaysSteps: Int
-
-
-    override public var todaysSteps: Int? {
-        get async {
-            try? await Task.sleep(for: .seconds(2))
-            return _todaysSteps
-        }
-    }
-
+    
 
     /// <#Description#>
     /// - Parameter todaysSteps: <#todaysSteps description#>
@@ -33,7 +25,12 @@ public class MockStepCountDataSource: StepCountDataSource {
 
     override public func steps(forDate date: Date) async -> Int? {
         try? await Task.sleep(for: .seconds(2))
-        return .random(in: 1000...20000)
+        
+        if Calendar.current.isDateInToday(date) {
+            return _todaysSteps
+        } else {
+            return .random(in: 1000...20000)
+        }
     }
 
     override public func requestStepAuthorization() async throws {


### PR DESCRIPTION
# Add HKAnchoredObjectQueryDescriptor

## :recycle: Current situation & Problem
The application currently does not refresh the UI when new step count information is added.

## :bulb: Proposed solution
This PR adds an `HKAnchoredObjectQueryDescriptor` to observe the step count data and refresh the daily steps every time new element have been added.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

