### PR TITLE
.Disabled Button + AppStorage

### DIFF
--- a/GetMoovin/LongtermProgress/LongTermProgressChartView.swift
+++ b/GetMoovin/LongtermProgress/LongTermProgressChartView.swift
@@ -1,8 +1,9 @@
 //
-//  LongTermProgressChartView.swift
-//  GetMoovin
+// This source file is part of the CS342 2023 GetMoovin Team Application project
 //
-//  Created by Parthav Shergill on 28/02/23.
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
 //
 
 import Charts

--- a/GetMoovin/LongtermProgress/NewLongTermView.swift
+++ b/GetMoovin/LongtermProgress/NewLongTermView.swift
@@ -1,8 +1,9 @@
 //
-//  NewLongTermView.swift
-//  GetMoovin
+// This source file is part of the CS342 2023 GetMoovin Team Application project
 //
-//  Created by Parthav Shergill on 28/02/23.
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
 //
 
 import SwiftUI

--- a/GetMoovin/TodaysGoal/DailyProgressCircleView.swift
+++ b/GetMoovin/TodaysGoal/DailyProgressCircleView.swift
@@ -1,8 +1,9 @@
 //
-//  DailyProgressCircleView.swift
-//  GetMoovin
+// This source file is part of the CS342 2023 GetMoovin Team Application project
 //
-//  Created by Parthav Shergill on 27/02/23.
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
 //
 
 import ConfettiSwiftUI

--- a/GetMoovin/TodaysGoal/StepCountView.swift
+++ b/GetMoovin/TodaysGoal/StepCountView.swift
@@ -49,7 +49,6 @@ struct StepCountView: View {
             VStack {
                 if let todaysSteps = stepCountDataSource.todaysSteps {
                     Text("Today's step count: \(todaysSteps)")*/
-                    
                 } else {
                     ProgressView()
                         .padding()
@@ -68,7 +67,6 @@ struct StepCountView: View {
         .onChange(of: scenePhase) { _ in
             loadStepCount()
         }
-
     }
     
     

--- a/GetMoovinModules/Sources/GetMoovinOnboardingFlow/GoalSetting.swift
+++ b/GetMoovinModules/Sources/GetMoovinOnboardingFlow/GoalSetting.swift
@@ -13,10 +13,10 @@ import SwiftUI
 struct GoalSetting: View {
     @Binding private var onboardingSteps: [OnboardingFlow.Step]
     @AppStorage(StorageKeys.userInformation) var userInformation = UserInformation()
-    @State private var selectedAnswer: String = ""
+    @AppStorage(StorageKeys.selectedGoalAnswer) var userSelectedGoal = ""
     
     let questionText = "To get an idea of your daily step count, simply check your phone."
-    let answerChoices = ["1,000 - 4,999", "5,000 - 7,499", "7,500 - 9,999", "10,000 <"]
+    let answerChoices = ["1,000 - 4,999", "5,000 - 7,499", "7,500 - 9,999", "10,000+"]
     
     var body: some View {
         VStack {
@@ -27,22 +27,28 @@ struct GoalSetting: View {
                     .frame(maxWidth: .infinity) // Expand to full width
                     .bold()
             }
-        
             MultipleChoiceQuestion(
                 questionText: questionText,
                 choices: answerChoices,
-                selectedAnswer: $selectedAnswer
+                selectedAnswer: Binding(
+                    get: { userSelectedGoal },
+                    set: { newValue in
+                        userSelectedGoal = newValue
+                        saveSelectedGoal(newValue)
+                    }
+                )
             )
                 .font(.title) // Increase font size for better readability
                 .padding() // Add padding for better touch target
             
             Spacer()
-
+            
             OnboardingActionsView("GOAL_SETTING_ACTION".moduleLocalized) {
                 onboardingSteps.append(.healthKitPermissions)
             }
             .font(.title) // Increase font size for better readability
             .padding() // Add padding for better touch target
+            .disabled(userSelectedGoal.isEmpty)
         }
         .padding(.horizontal, 24)
         .navigationTitle("GOAL_SETTING_TITLE".moduleLocalized)
@@ -51,6 +57,10 @@ struct GoalSetting: View {
     
     init(onboardingSteps: Binding<[OnboardingFlow.Step]>) {
         self._onboardingSteps = onboardingSteps
+    }
+    
+    func saveSelectedGoal(_ newAnswer: String) {
+        userSelectedGoal = newAnswer
     }
 }
 

--- a/GetMoovinModules/Sources/GetMoovinOnboardingFlow/Information.swift
+++ b/GetMoovinModules/Sources/GetMoovinOnboardingFlow/Information.swift
@@ -6,13 +6,15 @@
 // SPDX-License-Identifier: MIT
 //
 
+import GetMoovinSharedContext
 import Onboarding
 import SwiftUI
 
-
 struct Information: View {
     @Binding private var onboardingSteps: [OnboardingFlow.Step]
-    @State private var selectedAnswer: String = ""
+    @AppStorage(StorageKeys.userInformation) var userInformation = UserInformation()
+    
+    @AppStorage(StorageKeys.userSelectedAnswer) var selectedAnswer = ""
     
     let questionText = "In other words, what decade do you hope to live?"
     let answerChoices = ["60-69", "70-79", "80-89", "90-99"]
@@ -29,10 +31,16 @@ struct Information: View {
             MultipleChoiceQuestion(
                 questionText: questionText,
                 choices: answerChoices,
-                selectedAnswer: $selectedAnswer
+                selectedAnswer: Binding(
+                    get: { selectedAnswer },
+                    set: { newValue in
+                        selectedAnswer = newValue
+                        saveSelectedAnswer(newValue)
+                    }
+                )
             )
-                .font(.title) // Increase font size for better readability
-                .padding() // Add padding for better touch target
+            .font(.title) // Increase font size for better readability
+            .padding() // Add padding for better touch target
             
             Spacer()
             
@@ -41,6 +49,7 @@ struct Information: View {
             }
             .font(.title) // Increase font size for better readability
             .padding() // Add padding for better touch target
+            .disabled(selectedAnswer.isEmpty)
         }
         .padding(.horizontal, 24)
         .navigationTitle("INFORMATION_TITLE".moduleLocalized)
@@ -49,6 +58,10 @@ struct Information: View {
     
     init(onboardingSteps: Binding<[OnboardingFlow.Step]>) {
         self._onboardingSteps = onboardingSteps
+    }
+    
+    func saveSelectedAnswer(_ newAnswer: String) {
+        selectedAnswer = newAnswer
     }
 }
 

--- a/GetMoovinModules/Sources/GetMoovinSharedContext/StorageKeys.swift
+++ b/GetMoovinModules/Sources/GetMoovinSharedContext/StorageKeys.swift
@@ -22,5 +22,11 @@ public enum StorageKeys {
     
     // MARK: - User Information
     /// The current information of the user
-    public static let userInformation = "userinformation"
+    public static let userInformation = "userInformation"
+    
+    /// The user ultimate decade
+    public static let userSelectedAnswer = "userSelectedAnswer"
+    
+    /// The user step goal
+    public static let selectedGoalAnswer = "userSelectedGoal"
 }

--- a/GetMoovinUITests/OnboardingTests.swift
+++ b/GetMoovinUITests/OnboardingTests.swift
@@ -10,7 +10,6 @@ import XCTest
 import XCTestExtensions
 import XCTHealthKit
 
-
 class OnboardingTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -60,11 +59,39 @@ extension XCUIApplication {
     
     private func navigateOnboardingFlowInformation() throws {
         XCTAssertTrue(buttons["Next"].waitForExistence(timeout: 2))
+        
+        // Check that the answer choices are displayed
+        XCTAssertTrue(buttons["60-69"].exists)
+        XCTAssertTrue(buttons["70-79"].exists)
+        XCTAssertTrue(buttons["80-89"].exists)
+        XCTAssertTrue(buttons["90-99"].exists)
+        
+        // Select an answer
+        buttons["70-79"].tap()
+        
+        // Check that the next button is enabled
+        XCTAssertTrue(buttons["Next"].isEnabled)
+        
+        // Tap the next button
         buttons["Next"].tap()
     }
     
     private func navigateOnboardingFlowGoalSetting() throws {
         XCTAssertTrue(buttons["Next"].waitForExistence(timeout: 2))
+        
+        // Check that the answer choices are displayed
+        XCTAssertTrue(buttons["1,000 - 4,999"].exists)
+        XCTAssertTrue(buttons["5,000 - 7,499"].exists)
+        XCTAssertTrue(buttons["7,500 - 9,999"].exists)
+        XCTAssertTrue(buttons["10,000+"].exists)
+        
+        // Select an answer
+        buttons["1,000 - 4,999"].tap()
+        
+        // Check that the next button is enabled
+        XCTAssertTrue(buttons["Next"].isEnabled)
+        
+        // Tap the next button
         buttons["Next"].tap()
     }
     


### PR DESCRIPTION
… an answer before proceeding.

Utilized AppStorage to store the responses from the two onboarding questions.

<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# *Onboarding: .disabled button + App Storage*

## :recycle: Current situation & Problem
*Previously, the users answers would not save, as it refreshes every time.*
*Previously, the user could click the next button without picking an answer.*

## :bulb: Proposed solution
*Now, the users answers are stored within AppStorage*
*The user cannot click the next button without picking an answer (.disabled button)*

## :gear: Release Notes 
*1. The answers are currently now stored  

2. The next buttons currently cannot be pressed unless the user selected an answer. Implemented a .disabled  modifier in SwiftUI that allows this behavior. Disable the buttons if the user has not yet provided an answer. 

## :heavy_plus_sign: Additional Information
*Provide some additional information if possible*

### Related PRs
*Reference the related PRs*

### Testing
*Tests are included to see if the .disabled button works and does not move on until it chooses a MC button, enabling the next button for both Information and GoalSetting*

### Reviewer Nudging
*Where should the reviewer start? Where is a good entry point?*
@anushehchaudry 

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

